### PR TITLE
[NOT FOR MERGING] feat(tamagui-build): generate source map for .mjs

### DIFF
--- a/packages/build/tamagui-build.js
+++ b/packages/build/tamagui-build.js
@@ -485,7 +485,7 @@ async function esbuildWriteIfChanged(
     allowOverwrite: true,
     keepNames: false,
     sourcemap: true,
-    sourcesContent: false,
+    sourcesContent: true,
     logLevel: 'error',
     ...(platform === 'native' && nativeEsbuildSettings),
     ...(platform === 'web' && webEsbuildSettings),
@@ -603,11 +603,12 @@ async function esbuildWriteIfChanged(
           const mjsOutPath = outPath.replace('.js', '.mjs')
           // if bundling no need to specify as its all internal
           // and babel is bad on huge bundled files
-          const output = shouldBundle
+          const { out: output, map: sourceMap } = shouldBundle
             ? outString
             : transform(outString, {
                 filename: mjsOutPath,
                 configFile: false,
+                sourceMap: true,
                 plugins: [
                   [
                     require.resolve('@tamagui/babel-plugin-fully-specified'),
@@ -622,10 +623,11 @@ async function esbuildWriteIfChanged(
                   //   ? null
                   //   : require.resolve('./babel-plugin-process-env-to-meta'),
                 ].filter(Boolean),
-              }).code
+              })
 
           // output to mjs fully specified
           await fs.writeFile(mjsOutPath, output, 'utf8')
+          await fs.writeFile(mjsOutPath + '.map', JSON.stringify(sourceMap), 'utf8')
         }
       })()
     })

--- a/packages/build/tamagui-build.js
+++ b/packages/build/tamagui-build.js
@@ -9,7 +9,7 @@ const esbuild = require('esbuild')
 const fg = require('fast-glob')
 const createExternalPlugin = require('./externalNodePlugin')
 const debounce = require('lodash.debounce')
-const { dirname } = require('path')
+const { dirname, basename } = require('path')
 const alias = require('./esbuildAliasPlugin')
 
 const jsOnly = !!process.env.JS_ONLY
@@ -603,7 +603,7 @@ async function esbuildWriteIfChanged(
           const mjsOutPath = outPath.replace('.js', '.mjs')
           // if bundling no need to specify as its all internal
           // and babel is bad on huge bundled files
-          const { out: output, map: sourceMap } = shouldBundle
+          const { code: output, map: sourceMap } = shouldBundle
             ? outString
             : transform(outString, {
                 filename: mjsOutPath,
@@ -626,7 +626,7 @@ async function esbuildWriteIfChanged(
               })
 
           // output to mjs fully specified
-          await fs.writeFile(mjsOutPath, output, 'utf8')
+          await fs.writeFile(mjsOutPath, output + `\n//# sourceMappingURL=${basename(mjsOutPath)}.map\n`, 'utf8')
           await fs.writeFile(mjsOutPath + '.map', JSON.stringify(sourceMap), 'utf8')
         }
       })()


### PR DESCRIPTION
**This PR is for notes and explanation, it's not meant to be merged.**

## Purpose

Let `tamagui-build` output source maps that can be more friendly to debuggers, specifically for code tracing `vxrn` with VSCode debugger, so one can set breakpoints and see what's being executed in the source code directly instead of in `dist/`.